### PR TITLE
proxy kormir into a worker

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -51,7 +51,7 @@ export function EventList() {
   const [state, _actions] = useMegaStore();
 
   const getEvents = async () => {
-    return (await state.kormir?.list_events()) as EventData[];
+    return await state.kormir?.list_events();
   };
 
   const [events, { refetch }] = createResource(getEvents);
@@ -65,7 +65,7 @@ export function EventList() {
   const onSave = async () => {
     setDialogOpen(false);
     await refetch();
-  }
+  };
 
   return (
     <>

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -1,16 +1,18 @@
-import { Show, Suspense } from "solid-js";
+import { Show, Suspense, createResource } from "solid-js";
 import { EventList } from "~/components";
 import { useMegaStore } from "~/state/megaStore";
 
 export function Home() {
   const [state, _actions] = useMegaStore();
 
+  const [pubKey] = createResource(async () => state.kormir?.get_public_key());
+
   return (
     <main class="flex flex-col gap-4 items-center w-full max-w-[40rem] mx-auto">
       <h1 class="font-mono text-4xl drop-shadow-text-glow p-8 font-bold">
         Kormir
       </h1>
-      <pre>{state.kormir?.get_public_key()}</pre>
+      <pre>{pubKey()}</pre>
       <Show when={state.kormir !== undefined}>
         <Suspense>
           <EventList />

--- a/src/state/kormirProxy.ts
+++ b/src/state/kormirProxy.ts
@@ -1,0 +1,90 @@
+import { EventData } from "@benthecarman/kormir-wasm";
+
+export interface KormirMethods {
+  new: (relays: string[]) => Promise<KormirProxy>;
+  get_public_key: () => Promise<string>;
+  create_enum_event: (
+    event_id: string,
+    outcomes: string[],
+    event_maturity_epoch: number,
+  ) => Promise<string>;
+  sign_enum_event: (id: number, outcome: string) => Promise<string>;
+  list_events: () => Promise<any>;
+  // ... other methods as needed
+}
+
+export type KormirMethodNames = keyof KormirMethods;
+
+export class KormirProxy {
+  private worker: SharedWorker;
+  private id: string;
+
+  constructor(worker: SharedWorker, id: string) {
+    this.worker = worker;
+    this.id = id;
+  }
+
+  private sendMessage<K extends KormirMethodNames>(
+    method: K,
+    args: Parameters<KormirMethods[K]>,
+  ): ReturnType<KormirMethods[K]> {
+    return new Promise((resolve, reject) => {
+      const messageHandler = (event: MessageEvent) => {
+        if (event.data.id === this.id) {
+          this.worker.port.removeEventListener("message", messageHandler);
+          if (event.data.error) {
+            reject(new Error(event.data.error));
+          } else {
+            resolve(event.data.result);
+          }
+        }
+      };
+
+      this.worker.port.addEventListener("message", messageHandler);
+      this.worker.port.start(); // Start the port if not already started
+      this.worker.port.postMessage({ id: this.id, method, args });
+    }) as ReturnType<KormirMethods[K]>;
+  }
+
+  public static new(relays: string[]): Promise<KormirProxy> {
+    const worker = new SharedWorker(
+      new URL("../workers/kormir.ts", import.meta.url),
+      { type: "module" },
+    );
+    const id = generateUniqueId(); // Implement this function to generate unique IDs.
+    const proxy = new KormirProxy(worker, id);
+    return proxy.sendMessage("new", [relays]).then(() => proxy); // Return the proxy after initialization
+  }
+
+  public get_public_key(): Promise<string> {
+    return this.sendMessage("get_public_key", []);
+  }
+
+  public create_enum_event(
+    event_id: string,
+    outcomes: string[],
+    event_maturity_epoch: number,
+  ): Promise<string> {
+    return this.sendMessage("create_enum_event", [
+      event_id,
+      outcomes,
+      event_maturity_epoch,
+    ]);
+  }
+
+  public sign_enum_event(id: number, outcome: string): Promise<string> {
+    return this.sendMessage("sign_enum_event", [id, outcome]);
+  }
+
+  public list_events(): Promise<EventData[]> {
+    return this.sendMessage("list_events", []);
+  }
+
+  // ... Add other methods as needed
+}
+
+// Utility function to generate unique IDs (implement accordingly)
+function generateUniqueId(): string {
+  // Implement a method to generate unique IDs, such as UUIDs or another method
+  return Math.random().toString(36).substring(2, 15);
+}

--- a/src/state/megaStore.tsx
+++ b/src/state/megaStore.tsx
@@ -1,10 +1,10 @@
 import { createStore } from "solid-js/store";
-import initKormir, { Kormir } from "@benthecarman/kormir-wasm";
+import { KormirProxy } from "./kormirProxy";
 import { ParentComponent, createContext, onMount, useContext } from "solid-js";
 
 export type MegaStore = [
   {
-    kormir?: Kormir;
+    kormir?: KormirProxy;
   },
   {
     setup: () => void;
@@ -16,13 +16,12 @@ const MegaStoreContext = createContext<MegaStore>();
 
 export const Provider: ParentComponent = (props) => {
   const [state, setState] = createStore({
-    kormir: undefined as Kormir | undefined,
+    kormir: undefined as KormirProxy | undefined,
   });
 
   const actions = {
     async setup() {
-      await initKormir();
-      const kormir = await Kormir.new(["wss://nostr.mutinywallet.com"]);
+      const kormir = await KormirProxy.new(["wss://nostr.mutinywallet.com"]);
       setState({ kormir });
     },
     async hello() {

--- a/src/workers/kormir.ts
+++ b/src/workers/kormir.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-restricted-globals */
+import initKormir, { Kormir } from "@benthecarman/kormir-wasm";
+import { KormirMethodNames } from "~/state/kormirProxy";
+
+interface KormirInstanceMap {
+  [id: string]: Kormir;
+}
+
+const kormirInstances: KormirInstanceMap = {};
+
+// Initialize the Kormir Wasm module once at the worker startup.
+let wasmInitialized = false;
+
+self.onconnect = (e: MessageEvent) => {
+  const port = e.ports[0];
+
+  port.onmessage = async (event: MessageEvent) => {
+    const { id, method, args } = event.data;
+
+    // Ensure Wasm is initialized before handling any messages
+    if (!wasmInitialized) {
+      try {
+        await initKormir();
+        wasmInitialized = true;
+      } catch (error) {
+        const e = error as Error;
+        port.postMessage({
+          id,
+          error: "Failed to initialize Kormir Wasm: " + e.message,
+        });
+        return;
+      }
+    }
+
+    try {
+      if (method === "new") {
+        const kormirInstance = await Kormir.new([
+          "wss://nostr.mutinywallet.com",
+        ]);
+        kormirInstances[id] = kormirInstance;
+        port.postMessage({ id, result: "Instance created" });
+      } else if (kormirInstances[id]) {
+        const kormirInstance = kormirInstances[id];
+        // Methods are called based on the name provided in the message.
+        // TypeScript doesn't know what methods are available on kormirInstance,
+        // so we need to use a type assertion here.
+        const result = await kormirInstance[method as KormirMethodNames](
+          ...args,
+        );
+        port.postMessage({ id, result });
+      }
+    } catch (error) {
+      const e = error as Error;
+      port.postMessage({ id, error: e.message });
+    }
+  };
+};


### PR DESCRIPTION
I don't quite have the typescript fu 100% solved but this seems to work! nice thing is it's pretty minimal change from the megastore / rest of the app perspective. the KormirProxy object is meant to look / behave just like Kormir, except it passes all the method calls off to the SharedWorker.